### PR TITLE
riotgen/templates: fix template for driver

### DIFF
--- a/riotgen/templates/driver/driver.c.j2
+++ b/riotgen/templates/driver/driver.c.j2
@@ -13,8 +13,8 @@
  */
 
 #include "{{ driver.name }}.h"
-#include "{{ driver.name }}_constants.h"
-#include "{{ driver.name }}_params.h"
+#include "include/{{ driver.name }}_constants.h"
+#include "include/{{ driver.name }}_params.h"
 
 int {{ driver.name }}_init({{ driver.name }}_t *dev, const {{ driver.name }}_params_t *params)
 {

--- a/riotgen/tests/test_data/driver/driver.c
+++ b/riotgen/tests/test_data/driver/driver.c
@@ -19,8 +19,8 @@
  */
 
 #include "test.h"
-#include "test_constants.h"
-#include "test_params.h"
+#include "include/test_constants.h"
+#include "include/test_params.h"
 
 int test_init(test_t *dev, const test_params_t *params)
 {


### PR DESCRIPTION
Some header files for the driver were created within a directory `include/`, but the directory was not included in the include path. At least locally the files will be found now.