### PR TITLE
Fx minor typo in app template (s/USE_PKG/USEPKG/).

### DIFF
--- a/riotgen/templates/application/Makefile.j2
+++ b/riotgen/templates/application/Makefile.j2
@@ -32,7 +32,7 @@ FEATURES_REQUIRED += {{ feature }}
 
 # required packages
 {% for package in application.packages %}
-USE_PKG += {{ package }}
+USEPKG += {{ package }}
 {% endfor %}
 {% endif %}
 


### PR DESCRIPTION
This PR fixes a minor typo in application template which silently ignores required packages.

It was faster to directly submit a PR than to open an issue. If this violates your workflow in any way, please feel free to ignore it and apply the changes otherwise in the next version.