### PR TITLE
riotgen/templates: don't call cpu_init() on latest RIOT

### DIFF
--- a/riotgen/templates/board/board.c.j2
+++ b/riotgen/templates/board/board.c.j2
@@ -18,6 +18,8 @@
 
 void board_init(void)
 {
+#if RIOT_VERSION_CODE < RIOT_VERSION_NUM(2022, 1, 0, 0)
     /* initialize the CPU */
     cpu_init();
+#endif
 }


### PR DESCRIPTION
In RIOT master boards no longer need to call `cpu_init()`.
If someone is using RIOT 2021.10 however, they must still make sure to call the function from `board_init()`.

We can drop this block entirely once the 2022.01 release is out.