### PR TITLE
templates: Fix USEPKG

### DIFF
--- a/riotgen/templates/driver/Makefile.dep.j2
+++ b/riotgen/templates/driver/Makefile.dep.j2
@@ -10,6 +10,6 @@ FEATURES_REQUIRED += {{ feature }}
 {% endif %}
 {% if driver.packages|length > 0 %}
 {% for package in driver.packages %}
-USE_PKG += {{ package }}
+USEPKG += {{ package }}
 {% endfor %}
 {% endif %}

--- a/riotgen/templates/pkg/Makefile.dep.j2
+++ b/riotgen/templates/pkg/Makefile.dep.j2
@@ -17,6 +17,6 @@ FEATURES_REQUIRED += {{ feature }}
 
 # required packages
 {% for package in pkg.packages %}
-USE_PKG += {{ package }}
+USEPKG += {{ package }}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
This fixes the templates for drivers and packages. RIOT's way of declaring package dependencies is by extending the make variable `USEPKG` (https://doc.riot-os.org/group__pkg.html).