### PR TITLE
treewide: make position of Doxygen opening bracket consistent

### DIFF
--- a/riotgen/__init__.py
+++ b/riotgen/__init__.py
@@ -10,4 +10,4 @@ It can be used to bootstrap:
 - a new package for RIOT
 """
 
-__version__ = "0.14.0"
+__version__ = "0.15.0"

--- a/riotgen/templates/driver/driver.h.j2
+++ b/riotgen/templates/driver/driver.h.j2
@@ -4,7 +4,6 @@
  * @defgroup    drivers_{{ driver.name }} {{ driver.displayed_name }}
  * @ingroup     drivers_{{ driver.ingroup }}
  * @brief       {{ driver.brief }}
- *
  * @{
  *
  * @file

--- a/riotgen/templates/driver/driver_netdev.c.j2
+++ b/riotgen/templates/driver/driver_netdev.c.j2
@@ -3,6 +3,7 @@
 /**
  * @ingroup     drivers_{{ driver.name }}
  * @{
+ *
  * @file
  * @brief       Netdev adaptation for the {{ driver.displayed_name }} driver
  *

--- a/riotgen/templates/driver/driver_netdev.h.j2
+++ b/riotgen/templates/driver/driver_netdev.h.j2
@@ -3,6 +3,7 @@
 /**
  * @ingroup     drivers_{{ driver.name }}
  * @{
+ *
  * @file
  * @brief       Netdev driver definitions for {{ driver.displayed_name }} driver
  *

--- a/riotgen/templates/driver/driver_params.h.j2
+++ b/riotgen/templates/driver/driver_params.h.j2
@@ -2,8 +2,8 @@
 
 /**
  * @ingroup     drivers_{{ driver.name }}
- *
  * @{
+ *
  * @file
  * @brief       Default configuration
  *

--- a/riotgen/templates/module/module.h.j2
+++ b/riotgen/templates/module/module.h.j2
@@ -4,7 +4,6 @@
  * @defgroup    sys_{{ module.name }} {{ module.displayed_name }}
  * @ingroup     sys
  * @brief       {{ module.brief }}
- *
  * @{
  *
  * @file

--- a/riotgen/tests/test_data/driver/driver.h
+++ b/riotgen/tests/test_data/driver/driver.h
@@ -9,7 +9,6 @@
  * @defgroup    drivers_test Test
  * @ingroup     drivers_misc
  * @brief       test brief description
- *
  * @{
  *
  * @file

--- a/riotgen/tests/test_data/driver/driver_params.h
+++ b/riotgen/tests/test_data/driver/driver_params.h
@@ -7,8 +7,8 @@
 
 /**
  * @ingroup     drivers_test
- *
  * @{
+ *
  * @file
  * @brief       Default configuration
  *

--- a/riotgen/tests/test_data/driver_netdev/driver.h
+++ b/riotgen/tests/test_data/driver_netdev/driver.h
@@ -9,7 +9,6 @@
  * @defgroup    drivers_test Test
  * @ingroup     drivers_netdev
  * @brief       test brief description
- *
  * @{
  *
  * @file

--- a/riotgen/tests/test_data/driver_netdev/driver_netdev.c
+++ b/riotgen/tests/test_data/driver_netdev/driver_netdev.c
@@ -6,6 +6,7 @@
 /**
  * @ingroup     drivers_test
  * @{
+ *
  * @file
  * @brief       Netdev adaptation for the Test driver
  *

--- a/riotgen/tests/test_data/driver_netdev/driver_netdev.h
+++ b/riotgen/tests/test_data/driver_netdev/driver_netdev.h
@@ -8,6 +8,7 @@
 /**
  * @ingroup     drivers_test
  * @{
+ *
  * @file
  * @brief       Netdev driver definitions for Test driver
  *

--- a/riotgen/tests/test_data/driver_netdev/driver_params.h
+++ b/riotgen/tests/test_data/driver_netdev/driver_params.h
@@ -7,8 +7,8 @@
 
 /**
  * @ingroup     drivers_test
- *
  * @{
+ *
  * @file
  * @brief       Default configuration
  *

--- a/riotgen/tests/test_data/module/module.h
+++ b/riotgen/tests/test_data/module/module.h
@@ -9,7 +9,6 @@
  * @defgroup    sys_test Test
  * @ingroup     sys
  * @brief       test brief description
- *
  * @{
  *
  * @file


### PR DESCRIPTION
Semantically, the opening bracket in a Doxygen header belongs to `@ingroup` (although I'm not sure if `@ingroup` actually supports grouping, I vaguely remember an issue in the RIOT issue tracker... but that's not the point), so it should be close to `@ingroup`, but more importantly, it should be uniform.

Discovered in https://github.com/RIOT-OS/RIOT/pull/22451#discussion_r3543408664